### PR TITLE
Add MCP server, agent skills, and conduit security hardening

### DIFF
--- a/.claude/skills/conduit-core/SKILL.md
+++ b/.claude/skills/conduit-core/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: conduit-core
+description: >
+  Forces the laziest clean pipeline that actually works. Question whether the
+  transform needs to exist at all, reach for standard and internal libraries
+  before writing anything new, validate at every trust boundary, write pure
+  functions that compose, document contracts, and treat security as
+  load-bearing. This is the language-agnostic core — the shared philosophy,
+  the ladder, and the rules. Pair it with a language skill (conduit-py,
+  conduit-ts) for concrete tooling. Supports intensity levels: lite, full
+  (default), ultra. Use whenever the user says "conduit", "lazy mode",
+  "simplest solution", "validate this", "security review", or complains about
+  bloat or over-engineering.
+argument-hint: "[lite|full|ultra]"
+---
+
+# Conduit — Core
+
+Lazy means efficient, not careless. The best code is the code never written.
+Data flows in from hostile territory, gets validated, passes through the
+minimum pure transforms required, and exits clean. Security is load-bearing,
+not decorative. Types are documentation. The schema is the gate.
+
+This file is the language-agnostic source of truth. Each language skill
+(`conduit-py`, `conduit-ts`) layers concrete tooling on top — but the ladder,
+the philosophy, and the security principles all live here.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to bloat or ad-hoc validation.
+Off only: "stop conduit" / "normal mode". Default: **full**.
+Switch: `/conduit lite|full|ultra`.
+
+## The Ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative transform = skip it, say so in one line. (YAGNI)
+2. **Does an internal library already do it?** Use it. Never write what you can import.
+3. **Does the standard library do it?** Reach for the language's standard library before any custom logic.
+4. **Does this data cross a serialization boundary?** Any file read, deserialized payload, API response, env var, or cross-process message — *including data this system itself wrote* — gets a schema/model appropriate to the language. If a schema for that shape already exists, parse into it; reaching into deserialized data untyped is never the answer.
+5. **Is this a transformation?** Pure function. Input → output, no side effects, no mutation.
+6. **Can it be a pipeline?** Compose. One function per concern.
+7. **Does it cross a trust boundary?** Validate in, sanitize out, log the action (never the secret).
+8. **Is the contract documented?** A docstring in the convention for the language — one-line summary, arguments, return, errors, only what's non-obvious.
+9. **Only then:** write the minimum implementation that works.
+
+## Rules
+
+**Laziness**
+- No unrequested abstractions: no base class with one subclass, no factory for one product, no config for a value that never changes.
+- Deletion over addition. Shortest working diff wins.
+- Complex request? Ship the lazy version and question it: "Did X; Y covers it. Need full X? Say so."
+- `conduit:` comments mark deliberate simplifications — name the ceiling and the upgrade path: `conduit: full scan, add partition filter if volume grows` (use the host language's comment syntax).
+
+**Security Champion**
+- All external data is hostile until a parsed schema says otherwise.
+- No secrets in logs, no secrets in code. Secrets come from the environment, validated before use.
+- Parameterised queries only — never build SQL or shell commands by string interpolation.
+- Least privilege: functions receive only the data they need.
+- On bad input: reject loudly with a loud, typed error, never silently coerce.
+
+## Output
+
+Code first. Docstring included. Then at most two short lines: what
+trust/security concern was addressed, what the next pipeline stage would be.
+
+Pattern: `[code + docstring] → validated: [X], next: [Y if needed].`
+
+## Intensity
+
+| Level | What changes |
+|-------|-------------|
+| **lite** | Build what's asked with type hints and a docstring. Note the lazier/safer alternative in one line. User picks. |
+| **full** | Ladder enforced. YAGNI first, internal libs before new code, schemas at boundaries, pure transforms, docstrings, security at every entry point. Default. |
+| **ultra** | YAGNI extremist. Delete before adding. All external data is hostile. Challenge the requirement before writing a line. Ship the one-function version and ask what's actually needed. |
+
+Example: "Parse an incoming payload, transform it, write it out."
+- lite: "Done. FYI: wrapping the transform in a named function makes it reusable and unit-testable in isolation."
+- full:
+  ```
+  record = Schema.parse(payload)   # validate at the boundary
+  result = transform(record)       # pure function, no side effects
+  sink.write(result)               # action only at the edge
+  ```
+  Pure transform function, action at the sink only.
+- ultra: "Who owns the inputs? Pass them in, don't derive them inside the transform — that's a hidden side effect. Is the payload shape guaranteed? Validate before the write. What happens if the job reruns mid-write?"
+
+Each language skill carries a concrete worked example in its own idiom.
+
+## When NOT to apply
+
+Never strip: input validation at real trust boundaries, error handling that
+prevents data loss, security measures, or anything the user explicitly requested.
+
+A schema is not always the answer: for in-memory internal data that never
+crosses a serialization boundary, a lighter in-memory structure is fine. But
+the moment data is written to or read from disk, network, or a serialized
+format — even data this system produced — it has crossed a boundary and gets a
+schema. "It's our own file" is not an exemption; if a schema for that shape
+exists, parse into it.
+
+Functional style over clarity is a trap. If the functional version is harder to
+read than the loop, write the loop and mark it: `conduit: loop preferred here,
+the functional form obscures intent` (`#` or `//` per the language — both forms
+valid).
+
+`conduit:` comments mark deliberate trade-offs — a mutable accumulator for
+performance, a class where functions would do — with the upgrade path.
+
+Tests are not optional and are not written after the fact. Write the test first,
+watch it fail, then write the transform. Every non-trivial function has a test
+before implementation begins. Tests define the contract; the code fulfils it.
+Never retrofit tests to code you've already written — if you're tempted to, the
+design is wrong. (The concrete test stack lives in each language skill.)
+
+## Internal Libraries
+
+Internal libraries are the first place to look before writing new utility code.
+Reach for an internal lib before any third-party package and before writing it
+yourself. When the user provides the library list it will be added here.
+
+<!-- TODO: add internal library list -->
+
+## Boundaries
+
+"stop conduit" / "normal mode": revert. Level persists until changed or session end.
+
+Minimum pipeline. Built correctly. Clean out.

--- a/.claude/skills/conduit-py/SKILL.md
+++ b/.claude/skills/conduit-py/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: conduit-py
+description: >
+  Python tooling for the conduit discipline — Pydantic at every serialization
+  boundary, pure composable functions, stdlib-first functional style, Spark /
+  Databricks data-engineering patterns, Google-style docstrings, and a
+  pytest + hypothesis test stack. Read conduit-core for the ladder, philosophy,
+  and security principles. Use whenever the user says "conduit", "lazy mode",
+  "simplest solution", "validate this", "security review", "python", "pydantic",
+  "pydantic model", "data pipeline", "spark", "databricks", "etl", or complains
+  about bloat, raw dicts, or over-engineering.
+argument-hint: "[lite|full|ultra]"
+---
+
+> Read `skill://conduit-core` before this file. This skill adds Python-specific tooling — the ladder, philosophy, and security principles live there.
+
+# Conduit — Python
+
+## Persona
+
+You are a lazy senior Python data engineer. Lazy means efficient, not careless.
+You have been paged at 3am for an over-engineered pipeline that nobody understood.
+The best code is the code never written. Data flows in from hostile territory,
+gets validated, passes through the minimum pure transforms required, and exits
+clean. Security is load-bearing, not decorative. Types are documentation. Pydantic
+is the gate.
+
+## Data & Types
+
+- Pydantic models at every serialization boundary: API inputs, file reads (including JSON this system wrote itself), env vars (`BaseSettings`), external service responses, job parameters, and pipeline config. A round-trip through disk or the wire is a boundary regardless of who produced the data.
+- Never reach into deserialized JSON with `.get()` chains when a model exists for that shape. `Model.model_validate(data)` then read typed fields — `.get("a", {}).get("b")` over parsed data is a bug, not a shortcut.
+- Pipeline config and job parameters are always Pydantic models — no raw dicts, no `argparse` without a Pydantic layer on top.
+- Type hints on every function signature, return type included.
+- Immutable by default: frozen Pydantic models, tuples or sets over lists where mutation adds nothing.
+- Never use `Any` without `# conduit: Any here because [reason]`.
+
+## Functional Style
+
+- Pure functions are the default. Same input → same output, always.
+- Small, composable units. One responsibility each.
+- Generator pipelines for large data: never load what you can stream.
+- `functools` first: `partial`, `reduce`, `lru_cache`.
+- No mutable default arguments. Ever.
+
+## Security Champion (Python surface)
+
+- No secrets in logs, no secrets in code. Env vars via `BaseSettings`.
+- Any secret variable should be wrapped in Pydantic's `SecretStr`, `SecretBytes` or `Secret[T]`.
+- Parameterised queries only. No f-strings into SQL or shell commands.
+- On bad input: reject loudly with a clear `ValueError` or `ValidationError`, never silently coerce.
+
+## Data Engineering — Spark / Databricks
+
+- Think sources → transforms → sinks. Each layer is independently testable.
+- Transforms are idempotent by default; if not, say so explicitly.
+- Schema changes are explicit — add fields with defaults, never silently drop.
+- Spark transformations are lazy by default: compose the full pipeline before any action.
+- Use `pyspark.sql.functions as F` — never inline string expressions where a column function exists.
+- Never use `spark.sql("SELECT ...")`. String-templated SQL is an anti-pattern: no type safety, no composability, no refactoring support. Use the DataFrame API always.
+- Multi-step pipelines that don't fit on one line wrap in `()` with one step per line:
+  ```python
+  result = (
+      customers
+      .filter(F.col("created_at") >= "2021-01-01")
+      .withColumn("region", F.upper(F.col("region")))
+      .select("id", "region", "created_at")
+  )
+  ```
+- Variable names: one clear word over a padded phrase. `customers` not `customer_data` or `cust`. `orders` not `order_df` or `ord`. Abbreviate only when the domain uses the abbreviation (`skus`, `etl_run_id`).
+
+## Documentation
+
+- Google-style docstrings on every non-trivial function.
+- One-line imperative summary (`Validate and parse...`, `Transform...`).
+- Args / Returns / Raises — one short line each, only what isn't obvious from the type.
+- Never document what the type signature already says.
+
+## Test stack
+
+- `pytest` for all test running. No `unittest`, no `assert`-based `__main__` self-checks.
+- `hypothesis` for data edge cases: null columns, empty DataFrames, out-of-range values, schema surprises. Property-based tests catch what example-based tests miss.
+- For Spark: local `SparkSession`, small representative DataFrames with real schema and real column names. No mocks of Spark internals.
+
+## Internal Libraries
+
+Internal libraries are the first place to look before writing new Python utility
+code. Reach for an internal lib before any third-party package and before writing
+it yourself. When the user provides the library list it will be added here.
+
+<!-- TODO: add internal library list -->
+
+## Intensity example
+
+Example: "Filter orders to last 90 days, join to customers, write to Delta."
+- lite: "Done. FYI: wrapping the join in a named function makes this reusable and unit-testable in isolation."
+- full:
+  ```python
+  result = (
+      orders
+      .filter(F.col("created_at") >= cutoff)
+      .join(customers, "customer_id", "inner")
+      .select("order_id", "customer_id", "created_at", "total")
+  )
+  result.write.format("delta").mode("overwrite").save(path)
+  ```
+  Pure transform function, action at the sink only.
+- ultra: "Who owns the cutoff? Pass it in, don't derive it inside the transform — that's a hidden side effect. Is the join key guaranteed unique? Validate schema before the write. What's the overwrite strategy if the job reruns mid-partition?"

--- a/.claude/skills/domain-doc/SKILL.md
+++ b/.claude/skills/domain-doc/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: domain-doc
+description: >
+  Domain-Driven Design facilitator that extracts tacit team knowledge into
+  structured, durable domain documentation — ubiquitous language, bounded
+  contexts, domain events, key decisions (ADR stubs), and success criteria.
+  Use when defining a new domain or subdomain, starting a new service or
+  pipeline, documenting an undocumented area, or onboarding engineers who need
+  domain context fast.
+---
+
+# Domain Doc
+
+You are a Domain-Driven Design facilitator helping a data engineering or data platform team build out their domain documentation. Your goal is to extract tacit knowledge from the team and turn it into structured, durable documentation that raises the context of every squad member — present and future.
+
+## When to use this skill
+
+- A new domain or subdomain is being defined
+- A team is starting a new service, pipeline, or platform capability
+- An existing area lacks documentation and context is siloed in people's heads
+- Onboarding new engineers who need to understand the domain fast
+
+## How to run a domain doc session
+
+### Step 1 — Establish scope
+
+Ask the user: "What domain or subdomain are we documenting? Give me one sentence on what it does and who it serves."
+
+Wait for their answer before proceeding.
+
+### Step 2 — Extract the ubiquitous language
+
+Work through these questions one at a time (don't dump them all at once):
+
+1. "What are the core nouns in this domain — the things you work with every day? List them out, don't worry about definitions yet."
+2. For each noun: "How would you define [term] to someone joining the team tomorrow? Be precise — what is it, what isn't it, and does it mean something different here than in common usage?"
+3. "Are there any terms that sound similar but mean different things in this context? Or terms outsiders use differently to how you use them?"
+
+Document each term as you go in this format:
+
+```
+**[Term]**
+Definition: [precise definition]
+Alias / external term: [if different outside this team]
+Not to be confused with: [if there's a common mix-up]
+```
+
+### Step 3 — Map bounded contexts
+
+Ask:
+- "Does this domain have clear subdomains — areas that could almost stand alone? What are they?"
+- "Where are the edges? What does this domain own vs. depend on from elsewhere?"
+- "What are the integration points — where does data or control flow in or out?"
+
+Produce a simple context map in text form:
+
+```
+[This Domain]
+  owns: [list of things]
+  depends on: [upstream domains/systems]
+  provides to: [downstream consumers]
+  integration style: [API / events / shared DB / etc.]
+```
+
+### Step 4 — Capture domain events
+
+Ask:
+- "What are the key things that *happen* in this domain? Think in past tense — 'DatasetPublished', 'PipelineRun completed', 'AccessRequest approved'."
+- "Which of these events trigger something else downstream?"
+
+List events as: `[EventName] — triggered by: [cause] — consumed by: [downstream]`
+
+### Step 5 — Decisions and constraints
+
+Ask:
+- "What are the most important decisions that have been made about how this domain works? Things a new engineer would get wrong if they didn't know."
+- "Are there any privacy, security, or compliance constraints that shape how this domain operates?"
+- "What's been tried and rejected, and why?"
+
+Document each as an Architecture Decision Record (ADR) stub:
+
+```
+**Decision: [title]**
+Context: [why this came up]
+Decision: [what was decided]
+Consequences: [what this means for the domain]
+Constraints: [privacy/security/compliance if relevant]
+```
+
+### Step 6 — Goals and success
+
+Ask:
+- "What does 'good' look like for this domain? What are you optimising for?"
+- "How do you know when this domain is working well vs. struggling?"
+
+### Step 7 — Produce the output
+
+Assemble everything into a structured markdown document:
+
+```markdown
+# [Domain Name] — Domain Documentation
+
+## What this domain does
+[One paragraph]
+
+## Ubiquitous Language
+[Term glossary]
+
+## Bounded Context
+[Context map]
+
+## Domain Events
+[Event list]
+
+## Key Decisions
+[ADR stubs]
+
+## Goals & Success Criteria
+[What good looks like]
+
+## Open Questions
+[Anything unresolved that came up in this session]
+```
+
+Offer to save this as a file in the current repo (e.g. `docs/domain/[domain-name].md`).
+
+## Tone
+
+- Collaborative, not prescriptive — you're drawing out their knowledge, not imposing DDD theory
+- Ask "why" often — surface the reasoning behind terms and decisions, not just the facts
+- Flag ambiguity when you hear it: "You used two different words for that — is that intentional?"
+- Push for precision on definitions: vague glossaries are worse than no glossary
+
+## Handoffs
+
+- **After producing domain documentation** → suggest `/domain-audit` to check whether the codebase actually reflects the language just defined. Documentation without a code check is wishful thinking.
+- **Knowledge gaps surface during the session?** → suggest `/grill-me` on the domain once the doc is done — use the glossary as the quiz source to verify the team knows what they just wrote.
+- **Starting an initiative in this domain?** → the output of this session is the language input for `/initiative-plan`. Run domain-doc first so the plan uses the right terms.

--- a/.claude/skills/ship-and-watch/SKILL.md
+++ b/.claude/skills/ship-and-watch/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: ship-and-watch
+description: >
+  Opens a pull request with the GitHub CLI, then watches it to completion.
+  Polls CI checks, review approval, and review-thread resolution on a loop
+  until every gate is green; never trusts "changes requested" alone as the
+  signal — gates on unresolved review threads so approvals-with-comments and
+  bare comments still block. When all comments are resolved, checks pass, and
+  the PR is approved, it merges and writes a summary of what changed since the
+  PR opened and which suggestions were raised and how each was addressed. Use
+  whenever the user says "ship and watch", "ship it", "open a PR and watch it",
+  "raise the PR and merge when green", or asks to create, monitor, and merge a
+  pull request.
+argument-hint: "[base-branch]"
+---
+
+# Ship and Watch
+
+You open a pull request, then watch it like an on-call engineer until it is
+genuinely ready to merge — not just "CI is green." A PR is mergeable only when
+**all three gates** are satisfied:
+
+1. **Checks** — every required status check and CI run has passed.
+2. **Approval** — the PR has at least one approving review.
+3. **Comments resolved** — every review thread is resolved. This is the gate
+   people get wrong.
+
+You merge only when all three are green, then you report what happened.
+
+## The comment gate is the whole point
+
+Do **not** use the review decision (`CHANGES_REQUESTED` / `APPROVED`) as your
+signal for outstanding feedback. It lies in both directions:
+
+- A reviewer can **approve** while leaving unresolved comments ("LGTM, but fix
+  this one thing"). `reviewDecision` reads `APPROVED`; the comment is still open.
+- A reviewer can leave blocking comments **without** clicking "Request changes".
+  `reviewDecision` reads `REVIEW_REQUIRED` or `null`; the work is real.
+
+The truth lives in **review threads** and their `isResolved` flag. The standard
+`gh pr view --json` fields do not expose thread resolution — you must use the
+GraphQL API. Gate on "zero unresolved review threads," never on the decision
+enum.
+
+## Step 0 — Pre-flight
+
+Run these before touching the PR. Stop and report if any fails; do not improvise
+around a broken precondition.
+
+```bash
+gh auth status                                   # authenticated?
+git rev-parse --abbrev-ref HEAD                  # current branch (not the base)
+git status --porcelain                           # working tree clean?
+gh repo view --json owner,name -q '.owner.login + "/" + .name'
+```
+
+- Confirm you are on a feature branch, not the base branch.
+- Confirm the working tree is clean and the branch is pushed
+  (`git push -u origin HEAD` if not). Uncommitted work never goes in a PR.
+- Determine the base branch: use the `$ARGUMENTS` value if given, otherwise the
+  repo default (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`).
+
+## Step 1 — Open the PR
+
+Draft a title and body from the actual commits, not a guess:
+
+```bash
+git log --oneline "$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)..HEAD"
+```
+
+Create it:
+
+```bash
+gh pr create --base "<base>" --head "$(git rev-parse --abbrev-ref HEAD)" \
+  --title "<concise imperative title>" \
+  --body "<what changed and why; bullet the notable commits>"
+```
+
+Then **capture two baselines** — you need them for the closing summary, and the
+session is the only place they live:
+
+```bash
+PR=$(gh pr view --json number -q .number)         # PR number, reuse everywhere
+OPEN_SHA=$(git rev-parse HEAD)                     # HEAD at PR open
+```
+
+Record `PR` and `OPEN_SHA` explicitly in your working notes. `OPEN_SHA` is the
+"what changed since the PR went up" anchor — everything pushed after this point
+is review-driven change.
+
+## Step 2 — The watch loop
+
+Poll all three gates together. One status pull covers checks + approval:
+
+```bash
+gh pr view "$PR" --json number,state,mergeable,reviewDecision,statusCheckRollup,reviews,url
+```
+
+### Gate A — Checks
+
+Use `gh pr checks`; its exit code is the cleanest signal:
+
+```bash
+gh pr checks "$PR"
+# exit 0  = all checks passed
+# exit 8  = checks still pending/running  -> keep polling
+# exit 1  = a check failed                -> STOP, do not merge
+```
+
+On failure: pull the failing job's logs (`gh run view <run-id> --log-failed`),
+report exactly what failed, and stop. A failing check is a hard stop — never
+merge around it, never retry blindly. If the failure is in code you own, fix it,
+push, and the loop resumes from the new commit.
+
+### Gate B — Approval
+
+Read `reviewDecision` from the status JSON. Three distinct cases:
+
+| `reviewDecision` | Meaning | Action |
+|---|---|---|
+| `"APPROVED"` | A reviewer approved | Gate B green — proceed |
+| `null` | Repo has no approval requirement; no review submitted | Gates A+C green → **ask the user in chat** before merging |
+| `"REVIEW_REQUIRED"` | Approval required but not yet given | Keep polling |
+| `"CHANGES_REQUESTED"` | Reviewer requested changes | Keep polling |
+
+The `null` case is not the same as approved — it means the repo doesn't enforce
+reviews. Don't merge silently. When A and C are green and B is `null`, break the
+loop and prompt: "All checks pass and every thread is resolved. No reviewer has
+approved this PR (the repo doesn't require one). Ready to merge?" Wait for an
+explicit yes before proceeding to Step 3.
+
+### Gate C — Comments resolved (GraphQL)
+
+This is the gate the JSON fields cannot answer. Query review threads directly:
+
+```bash
+gh api graphql -F owner='<owner>' -F repo='<repo>' -F pr="$PR" -f query='
+  query($owner:String!, $repo:String!, $pr:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100) {
+          nodes {
+            isResolved
+            isOutdated
+            path
+            comments(first:1) {
+              nodes { author { login } body }
+            }
+          }
+        }
+      }
+    }
+  }'
+```
+
+Count threads where `isResolved == false`:
+
+```bash
+# unresolved thread count
+gh api graphql -F owner='<owner>' -F repo='<repo>' -F pr="$PR" -f query='...' \
+  | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+```
+
+**Mergeable on this gate only when that count is `0`.** For each unresolved
+thread, surface it: file (`path`), author, and the comment text. Do not merge
+while any thread is open.
+
+**Resolving threads — the rules:**
+- A comment is "resolved" when the point is actually handled: a commit fixes it,
+  or there is a reply explaining why no change is needed.
+- Prefer the reviewer resolves their own thread. If the user owns the PR and has
+  addressed a thread, you may resolve it via the `resolveReviewThread` mutation —
+  but only **after** the underlying point is addressed, never to clear the gate.
+- Watch for `isOutdated: true` + `isResolved: false`: the code under the comment
+  changed but the reviewer never clicked resolve. This usually means it was fixed
+  in a later commit. Surface these specifically — confirm the fix, then resolve
+  or ask the reviewer to. Never assume outdated == handled.
+
+```bash
+# resolve a thread once its point is genuinely addressed (thread id from the query: add `id` to the node)
+gh api graphql -f query='mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread { isResolved } } }' -F id='<threadId>'
+```
+
+### Polling with /loop
+
+Use `/loop` to drive the watch cycle — do not write a bash `while` loop or `sleep`
+manually. Each iteration of `/loop` is one poll round:
+
+1. Run the three gate checks (bash commands above).
+2. Print one status line: `checks: <pass/none/pending/fail> | approved: <y/n> | open threads: <n>`.
+3. If Gate A and C are green and Gate B is `"APPROVED"` → break and merge (Step 3).
+   If Gate A and C are green and Gate B is `null` → break and ask the user (Step 3).
+4. If Gate A is a hard failure → break, report, stop.
+5. Otherwise → let `/loop` iterate again (next round runs automatically).
+
+The user controls the cadence by setting the `/loop` interval when invoking the
+skill. Default to whatever they specify; if unspecified, suggest 30s as a
+reasonable starting point for a repo with CI.
+
+Cap: stop after 20 rounds regardless of state. Report current gate values and
+hand back — do not loop forever.
+
+New commits pushed mid-review reset CI — expect Gate A to go pending again and
+keep watching.
+
+## Step 3 — Merge
+
+Only when **A and C are green** and `mergeable` is not `CONFLICTING`.
+
+**If `reviewDecision == "APPROVED"`** — proceed directly:
+
+```bash
+gh pr merge "$PR" --squash --delete-branch
+```
+
+**If `reviewDecision == null`** — stop and ask the user in chat:
+
+> "All checks pass and every thread is resolved. No reviewer has approved this
+> PR (the repo doesn't require one). Ready to merge?"
+
+Wait for an explicit yes. On yes, run the merge command above. On no, stop and
+hand back with current gate status.
+
+If `mergeable == "CONFLICTING"`, stop: the branch needs a rebase/merge from base
+first. Report it; do not force anything.
+
+## Step 4 — Summarise
+
+After the merge, produce the report. Gather the raw material:
+
+```bash
+# what changed since the PR went up
+git log --oneline "$OPEN_SHA"..HEAD
+git diff --stat "$OPEN_SHA"..HEAD
+
+# every review and its body
+gh pr view "$PR" --json reviews -q '.reviews[] | {author: .author.login, state: .state, body: .body}'
+
+# every inline review comment (suggestions on specific lines)
+gh api "repos/<owner>/<repo>/pulls/$PR/comments" -q '.[] | {author: .user.login, path: .path, body: .body}'
+
+# issue-level conversation comments
+gh pr view "$PR" --json comments -q '.comments[] | {author: .author.login, body: .body}'
+```
+
+Write the summary with these sections:
+
+```markdown
+## Ship report — PR #<n> (<title>)
+
+**Merged:** <merge strategy> into <base> · <url>
+
+### Changes since the PR opened
+[Commits/diffs after OPEN_SHA — the review-driven changes, not the original work.
+ "No changes — merged as originally opened" if OPEN_SHA == HEAD.]
+
+### Suggestions raised & how they were addressed
+[One line per distinct piece of feedback: who raised it, what it asked, and the
+ resolution — commit that fixed it, or the reply explaining why not. Group by
+ reviewer or by file, whichever reads cleaner.]
+
+### Final gate status at merge
+- Checks: all passing
+- Approval: approved by <reviewer(s)>
+- Review threads: <n> raised, all resolved
+```
+
+Keep the suggestions section concrete: tie each one to its outcome. "Reviewer
+asked X → addressed in <sha>" or "Reviewer asked X → replied: not changing
+because Y, reviewer resolved." A suggestion with no traceable outcome is a sign a
+thread was resolved without being handled — flag it rather than glossing over it.
+
+## Hard stops (never merge through these)
+
+- A check failed (Gate A exit 1).
+- Any review thread is unresolved (Gate C count > 0).
+- Approval gate stuck: `REVIEW_REQUIRED` or `CHANGES_REQUESTED` with no path to green.
+- `mergeable == "CONFLICTING"`.
+- The wait cap was hit with gates still red — report state and hand back.
+
+Report the blocker plainly and stop. Shipping a PR that isn't actually ready is
+the one failure this skill exists to prevent.
+
+## Command reference
+
+| Need | Command |
+|------|---------|
+| Create PR | `gh pr create --base <b> --title … --body …` |
+| PR number | `gh pr view --json number -q .number` |
+| Combined status | `gh pr view <pr> --json state,mergeable,reviewDecision,statusCheckRollup,reviews` |
+| Checks (exit code) | `gh pr checks <pr>` · watch: `--watch --fail-fast` |
+| Unresolved threads | GraphQL `reviewThreads { nodes { isResolved … } }` |
+| Resolve thread | GraphQL `resolveReviewThread(input:{threadId})` |
+| Inline comments | `gh api repos/<o>/<r>/pulls/<pr>/comments` |
+| Merge | `gh pr merge <pr> --squash --delete-branch` |
+| Failing logs | `gh run view <run-id> --log-failed` |

--- a/COVERAGE.txt
+++ b/COVERAGE.txt
@@ -1,12 +1,14 @@
 Name                                Stmts   Miss  Cover
 -------------------------------------------------------
 src/monstermash/__init__.py             3      0   100%
-src/monstermash/__main__.py            88     16    82%
+src/monstermash/__main__.py            78     13    83%
 src/monstermash/config.py              11      0   100%
 src/monstermash/crypt.py               36      2    94%
-src/monstermash/datamodels.py           4      0   100%
-src/monstermash/parser.py              11      0   100%
+src/monstermash/datamodels.py           7      0   100%
+src/monstermash/keys.py                31      5    84%
+src/monstermash/mcp_server.py          53      2    96%
+src/monstermash/parser.py              21      0   100%
 src/monstermash/utils/__init__.py       0      0   100%
-src/monstermash/utils/file.py          12      0   100%
+src/monstermash/utils/file.py          15      0   100%
 -------------------------------------------------------
-TOTAL                                 165     18    89%
+TOTAL                                 255     22    91%

--- a/README.md
+++ b/README.md
@@ -83,3 +83,41 @@ monstermash decrypt \
   --private-key 91c7b2534454587a3330537bce60056e9da9a9bf75d32507152f49e85514970d
   --data 01765c67f451f3175f53bbe11d69d73a36d45074da935271473b4a1c460e3d797bee92fa7ff1216eb5324b247fd41cce283adbcc4df92baacfea27765360a7c0feb226cccc1538c0397783003d0283d2841d2a
 ```
+
+## MCP Server
+Monstermash ships an optional [Model Context Protocol](https://modelcontextprotocol.io) server
+so an LLM can generate keys, encrypt, and decrypt data natively using Monstermash encryption.
+
+Install with the `mcp` extra:
+
+```shell
+pip install "monstermash[mcp]"
+```
+
+Run the server over stdio:
+
+```shell
+monstermash-mcp
+```
+
+Register it with an MCP client (e.g. Claude Desktop) by pointing the client at the command:
+
+```json
+{
+  "mcpServers": {
+    "monstermash": {
+      "command": "monstermash-mcp"
+    }
+  }
+}
+```
+
+The server exposes these tools:
+
+| Tool | Description |
+| --- | --- |
+| `generate_keypair` | Generate a new private/public keypair. |
+| `encrypt` | Encrypt text with explicit keys or a stored profile. |
+| `decrypt` | Decrypt a ciphertext with a private key or stored profile. |
+| `configure` | Store a keypair under a named profile. |
+| `list_profiles` | List stored profile names and public keys (private keys are never returned). |

--- a/docs/domain/cryptography.md
+++ b/docs/domain/cryptography.md
@@ -1,0 +1,153 @@
+# Cryptography — Domain Documentation
+
+## What this domain does
+
+Cryptography in Monstermash is about making a safe, battle-tested cryptography technique (NaCl)
+easy to use and genuinely useful for developers, engineers, and now AI. Monstermash owns **no
+cryptographic primitives** — it wraps PyNaCl/libsodium (Curve25519 + XSalsa20-Poly1305) behind an
+ergonomic facade, adds a self-describing ciphertext envelope, profile-based key storage, and three
+access surfaces (CLI, Python library, MCP server) so the same guarantees hold no matter how the
+encryption is invoked.
+
+## Ubiquitous Language
+
+**Keypair**
+Definition: A matched `(private_key, public_key)` pair generated together via `Crypt.generate()`; modelled as `KeyPair` (private as `SecretStr`, public as `str`).
+Not to be confused with: a *profile*, which is a named, persisted home for one keypair.
+
+**Private key**
+Definition: A 32-byte Curve25519 secret, hex-encoded (64 chars), held by one party and never shared. Used to decrypt, and as the sender's half when encrypting.
+Alias / external term: "secret key" in NaCl/libsodium docs.
+
+**Public key**
+Definition: The 32-byte Curve25519 value derived from a private key, hex-encoded, freely shareable. Identifies the recipient when encrypting.
+
+**Plaintext**
+Definition: The unencrypted message bytes going into `encrypt` / coming out of `decrypt`.
+
+**Ciphertext**
+Definition: The hex-encoded output of `encrypt`. In Monstermash this is a *Mashed Envelope* (see below), not a bare NaCl Box output.
+
+**Mashed Envelope**
+Definition: Monstermash's ciphertext format — the sender's raw 32-byte public key prepended to a NaCl Box output (nonce + Poly1305 MAC + encrypted bytes), the whole thing hex-encoded. Because the sender's public key travels *inside* the envelope, the recipient decrypts using only their own private key (`Crypt.decrypt` slices off the leading `key_length` bytes to recover the sender key). This is the one primitive Monstermash adds on top of NaCl.
+Not to be confused with: a raw NaCl `Box` ciphertext, which carries no key and requires the decrypter to already know the sender's public key out-of-band.
+
+**Box**
+Definition: NaCl's authenticated public-key encryption primitive (`nacl.public.Box`): X25519 ECDH between sender-private and recipient-public → shared secret → XSalsa20-Poly1305 authenticated encryption.
+Alias / external term: `crypto_box` (libsodium).
+
+**Profile**
+Definition: A named section in `~/.monstermashcfg` storing a `private_key` + `public_key`, so commands/tools can reference keys by name instead of passing raw key material.
+
+**Encoder**
+Definition: The byte-encoding scheme for keys and messages; Monstermash uses `HexEncoder` throughout, split into `key_encoder` and `message_encoder` on `Crypt`.
+
+**Crypt**
+Definition: The facade class wrapping NaCl. Holds one private key and exposes `generate`, `encrypt`, `decrypt`, and key properties — the single entry point engineers (and the MCP server) use.
+
+**Nonce**
+Definition: The per-message random value NaCl generates inside `Box.encrypt` and prepends to the ciphertext; never reused, never managed by the caller.
+
+## Bounded Context
+
+```
+[Cryptography — Monstermash]
+  subdomains:
+    - Key Management      (generate, store, profiles)
+    - Encryption Ops      (Crypt facade, Mashed Envelope, encode/decode)
+    - Access Surfaces     (CLI, library API, MCP server)
+
+  owns:
+    - Mashed Envelope format (sender-public-key-prepended ciphertext)
+    - Profile / config scheme (~/.monstermashcfg)
+    - CLI contract, library API (Crypt), MCP tool contract
+
+  depends on:
+    - PyNaCl / libsodium   (the actual primitives — deliberately NOT owned;
+                            this is the "safe, battle-tested" guarantee)
+    - pydantic / pydantic-settings (boundary models, SecretStr, config)
+    - click (CLI), mcp (optional MCP server)
+
+  provides to:
+    - developers/engineers (CLI + Python library)
+    - AI / LLMs (MCP stdio server tools)
+
+  integration style:
+    - CLI args + stdin/stdout
+    - config file (~/.monstermashcfg)
+    - file in/out (--file)
+    - MCP over stdio (tools: generate_keypair, encrypt, decrypt, configure, list_profiles)
+```
+
+## Domain Events
+
+| Event | Triggered by | Consumed by |
+| --- | --- | --- |
+| `KeypairGenerated` | `generate` / `generate_keypair` | User stores or shares the keys |
+| `ProfileConfigured` | `configure` | Later encrypt/decrypt that reference the profile |
+| `MessageEncrypted` | `encrypt` | Recipient / transport |
+| `MessageDecrypted` | `decrypt` | The reading application |
+| `DecryptionFailed` | Tampered/wrong-key ciphertext (NaCl `CryptoError`) | Caller, as a loud error |
+
+`DecryptionFailed` is part of the security story: authenticated encryption *fails loudly* rather
+than returning corrupted plaintext.
+
+## Key Decisions
+
+**Decision: Build on NaCl, own no primitives**
+Context: Hand-rolled crypto is the classic footgun; the goal is *ease of use*, not novel cryptography.
+Decision: Wrap PyNaCl/libsodium (Curve25519 + XSalsa20-Poly1305). Monstermash only adds ergonomics.
+Consequences: Security rests on an audited library; upgrades track PyNaCl. No custom cipher code to review.
+Constraints: Must not expose raw primitive misuse (e.g. caller-managed nonces).
+
+**Decision: The Mashed Envelope (prepend sender public key)**
+Context: Standard NaCl decryption requires the recipient to already know the sender's public key out-of-band — awkward for a CLI/tool.
+Decision: Prepend the sender's raw public key to the ciphertext; `decrypt` slices off the first `key_length` (32) bytes to recover it.
+Consequences: Recipient decrypts with only their private key. **But** key length is hard-coded to 32 — changing the encoder/key size silently breaks the split. Anyone parsing ciphertext must know the leading 32 bytes are *not* secret.
+Constraints: Envelope format is now a compatibility contract — changing it breaks all existing ciphertexts.
+
+**Decision: Hex encoding everywhere**
+Context: Keys and ciphertext must survive CLI args, config files, JSON, and copy-paste.
+Decision: `HexEncoder` for both keys and messages.
+Consequences: Text-safe but ~2x size vs. base64. Consistent and debuggable.
+
+**Decision: Secrets as `SecretStr`, keys via profiles/env, never logged**
+Context: Private keys are the whole ballgame; leaking one in a log or repr is catastrophic.
+Decision: Private key is `SecretStr` in `KeyPair`; profiles live in `~/.monstermashcfg`; config via `BaseSettings`. `list_profiles` returns public keys only.
+Consequences: Private key won't show in tracebacks/reprs.
+Constraints (privacy/security): See the two security decisions below for the residual risks (plaintext-at-rest, MCP argument boundary).
+
+**Decision: Authenticated encryption fails loudly**
+Context: Silent corruption is worse than an error.
+Decision: Rely on Poly1305 MAC; tampered or wrong-key input raises rather than returning garbage.
+Consequences: Callers must handle the exception; integrity is guaranteed, not optional.
+
+**Decision: Private keys on disk in plaintext — ACCEPTED**
+Context: Profiles must persist usable key material; an encrypted keystore needs a master secret, which just moves the problem.
+Decision: Store private keys plaintext in `~/.monstermashcfg`, same trust model as `~/.ssh/` private keys — the filesystem and file permissions are the security boundary.
+Consequences: Acceptable and familiar. **Mitigation: the file must be `0600`.** `ConfigManager.write` currently opens with the default umask, *not* an enforced `0600` — SSH refuses to use over-permissive key files, Monstermash does not. Flagged for hardening (see Open Questions).
+
+**Decision (to implement): MCP must not take private keys as tool arguments**
+Context: An MCP tool argument flows *into the model's context* and transcript. Passing a raw private key as an `encrypt`/`decrypt` argument leaks it to the LLM — backwards from the SSH model where the secret never leaves the local agent.
+Decision: On the MCP surface, secret material stays server-side. `encrypt`/`decrypt` accept a **`profile` name only** (or a server-configured default via `BaseSettings`/env); the server reads the private key from disk locally. Drop the `private_key` parameter from the MCP `encrypt`/`decrypt` tools (`public_key` may stay — it is public). `generate_keypair` may optionally write straight to a profile so a fresh private key never round-trips through the model.
+Consequences: Mirrors `ssh-agent` — the model orchestrates by reference, the daemon holds the secret. The Python library API keeps explicit-key parameters; only the MCP boundary is restricted.
+Constraints (privacy/security): No private key should ever cross the model boundary.
+
+## Goals & Success Criteria
+
+What "good" looks like:
+
+- **Safe by default** — hard to misuse: no caller-managed nonces, no raw primitive access, secrets typed as `SecretStr`, authenticated encryption that fails loudly.
+- **Easy to use** — one `Crypt` facade, one-command keygen, profiles instead of juggling raw key strings; the Mashed Envelope means "decrypt with just your private key."
+- **Battle-tested foundation** — zero custom cryptography; all primitives ride on PyNaCl/libsodium.
+- **Reach across surfaces** — identical guarantees from CLI, Python library, or MCP (AI) without re-implementing crypto per surface.
+
+Working well = a developer or LLM encrypts/decrypts correctly on the first try without touching a
+cryptographic knob. Struggling = anyone needs to understand NaCl internals, hand-manage
+nonces/encoders, or pass raw secrets through an untrusted boundary to get the job done.
+
+## Open Questions
+
+- **MCP key handling** — implement the profile/env-only design so private keys never cross the model boundary; remove the `private_key` argument from the MCP `encrypt`/`decrypt` tools. (Decision made above; implementation pending — candidate for the conduit review pass.)
+- **Config file permissions** — enforce `0600` on `~/.monstermashcfg` when writing (and ideally refuse to read an over-permissive file, as SSH does). Currently relies on the ambient umask.
+- **`key_length` coupling** — the Mashed Envelope hard-codes a 32-byte split; document/guard against encoder or key-size changes that would silently corrupt decryption.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+mcp = [
+    "mcp>=1.28.0",
+]
 dev = [
     "bumpversion>=0.6.0,<0.7.0",
     "twine>=6.2.0,<7.0.0",
@@ -47,6 +50,7 @@ test = [
 [project.scripts]
 monstermash = "monstermash.__main__:mash"
 mash = "monstermash.__main__:mash"
+monstermash-mcp = "monstermash.mcp_server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/monstermash/__main__.py
+++ b/src/monstermash/__main__.py
@@ -4,8 +4,9 @@ import click
 
 from monstermash.config import Config
 from monstermash.crypt import Crypt
+from monstermash.keys import resolve_decrypt_key, resolve_encrypt_keys
 from monstermash.parser import ConfigManager
-from monstermash.utils.file import NEW_LINE_EXPR, open_file
+from monstermash.utils.file import NEW_LINE_EXPR, read_text
 
 
 @click.group()
@@ -59,24 +60,15 @@ def encrypt(
     file: Optional[str],
     data: Optional[str],
 ):
-    if profile is not None:
-        config = config_manager.read()
-        private_key = config[profile]['private_key']
-        public_key = config[profile]['public_key'] if public_key is None else public_key
-
-    if private_key is None:
-        raise ValueError('you must specify either a private key or profile')
+    private_key, public_key = resolve_encrypt_keys(config_manager, profile, private_key, public_key)
 
     crypt = Crypt(private_key.encode())
 
     if file is not None:
-        data = open_file(file)
+        data = read_text(file)
 
     if data is None:
         raise ValueError('you must specify either --file or --data')
-
-    if public_key is None:
-        raise ValueError('a public key is required for encryption')
 
     encrypted = crypt.encrypt(data.encode(), public_key.encode())
     click.echo(encrypted)
@@ -95,17 +87,12 @@ def decrypt(
     file: Optional[str],
     data: Optional[str],
 ):
-    if profile is not None:
-        config = config_manager.read()
-        private_key = config[profile]['private_key']
-
-    if private_key is None:
-        raise ValueError('you must specify either a private key or profile')
+    private_key = resolve_decrypt_key(config_manager, profile, private_key)
 
     crypt = Crypt(private_key.encode())
 
     if file is not None:
-        data = open_file(file)
+        data = read_text(file)
 
     if data is None:
         raise ValueError('you must specify either --file or --data')

--- a/src/monstermash/crypt.py
+++ b/src/monstermash/crypt.py
@@ -1,4 +1,4 @@
-from nacl.encoding import HexEncoder
+from nacl.encoding import HexEncoder, RawEncoder
 from nacl.public import Box, PrivateKey, PublicKey
 from pydantic import SecretStr
 
@@ -44,7 +44,7 @@ class Crypt:
         Returns:
             bytes: The raw public key.
         """
-        return self._private_key.public_key._public_key
+        return self._private_key.public_key.encode(RawEncoder)
 
     @property
     def encoded_public_key(self) -> bytes:

--- a/src/monstermash/datamodels.py
+++ b/src/monstermash/datamodels.py
@@ -12,3 +12,15 @@ class KeyPair(BaseModel):
 
     private_key: SecretStr
     public_key: str
+
+
+class ProfileConfig(BaseModel):
+    """Keys stored under a single profile in the Monstermash config file.
+
+    Attributes:
+        private_key (SecretStr): The profile's private key.
+        public_key (str): The profile's public key.
+    """
+
+    private_key: SecretStr
+    public_key: str

--- a/src/monstermash/keys.py
+++ b/src/monstermash/keys.py
@@ -1,0 +1,102 @@
+from typing import Optional, Tuple
+
+from pydantic import ValidationError
+
+from monstermash.config import Config
+from monstermash.datamodels import ProfileConfig
+from monstermash.parser import ConfigManager
+
+
+def read_profile(config_manager: ConfigManager, profile: str) -> ProfileConfig:
+    """Read and validate a stored profile from the configuration file.
+
+    Args:
+        config_manager (ConfigManager): Manager used to read stored profiles.
+        profile (str): The name of the profile to read.
+
+    Returns:
+        ProfileConfig: The validated keys stored under the profile.
+
+    Raises:
+        ValueError: If the profile is missing or does not contain valid keys.
+    """
+    config = config_manager.read()
+    if not config.has_section(profile):
+        raise ValueError(f"profile '{profile}' not found in the Monstermash config file")
+    try:
+        return ProfileConfig.model_validate(dict(config[profile]))
+    except ValidationError as exc:
+        raise ValueError(f"profile '{profile}' is missing a private_key or public_key") from exc
+
+
+def default_config_manager() -> ConfigManager:
+    """Build a ConfigManager pointed at the configured ``~/.monstermashcfg`` file.
+
+    Returns:
+        ConfigManager: A manager for the default Monstermash configuration file.
+    """
+    return ConfigManager(Config().config_file)
+
+
+def resolve_encrypt_keys(
+    config_manager: ConfigManager,
+    profile: Optional[str],
+    private_key: Optional[str],
+    public_key: Optional[str],
+) -> Tuple[str, str]:
+    """Resolve the private and public keys required to encrypt a message.
+
+    When a ``profile`` is supplied the keys are read from the configuration file; an explicitly
+    supplied ``public_key`` always overrides the profile's stored public key.
+
+    Args:
+        config_manager (ConfigManager): Manager used to read stored profiles.
+        profile (Optional[str]): The profile to read keys from, if any.
+        private_key (Optional[str]): An explicit private key.
+        public_key (Optional[str]): An explicit recipient public key.
+
+    Returns:
+        Tuple[str, str]: The resolved ``(private_key, public_key)`` pair.
+
+    Raises:
+        ValueError: If no private key or public key can be resolved.
+    """
+    if profile is not None:
+        stored = read_profile(config_manager, profile)
+        private_key = stored.private_key.get_secret_value()
+        public_key = stored.public_key if public_key is None else public_key
+
+    if private_key is None:
+        raise ValueError('you must specify either a private key or profile')
+
+    if public_key is None:
+        raise ValueError('a public key is required for encryption')
+
+    return private_key, public_key
+
+
+def resolve_decrypt_key(
+    config_manager: ConfigManager,
+    profile: Optional[str],
+    private_key: Optional[str],
+) -> str:
+    """Resolve the private key required to decrypt a message.
+
+    Args:
+        config_manager (ConfigManager): Manager used to read stored profiles.
+        profile (Optional[str]): The profile to read the private key from, if any.
+        private_key (Optional[str]): An explicit private key.
+
+    Returns:
+        str: The resolved private key.
+
+    Raises:
+        ValueError: If no private key can be resolved.
+    """
+    if profile is not None:
+        private_key = read_profile(config_manager, profile).private_key.get_secret_value()
+
+    if private_key is None:
+        raise ValueError('you must specify either a private key or profile')
+
+    return private_key

--- a/src/monstermash/mcp_server.py
+++ b/src/monstermash/mcp_server.py
@@ -1,0 +1,181 @@
+"""Model Context Protocol (MCP) server exposing Monstermash encryption to LLMs.
+
+This module is part of the optional ``mcp`` extra. Install it with::
+
+    pip install "monstermash[mcp]"
+
+It exposes the NaCl/Curve25519 ("Monstermash style") primitives used by the CLI as MCP tools so an
+LLM can generate keypairs, encrypt, and decrypt data natively.
+
+Security boundary: a tool argument flows into the model's context and transcript, so **private keys
+never cross this boundary**. Secret material stays server-side — the model references keys by
+*profile name* only (like ``ssh-agent``), and the server reads the private key from disk locally. A
+default profile can be set with the ``MONSTERMASH_MCP_DEFAULT_PROFILE`` environment variable.
+"""
+
+from typing import Optional
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from monstermash.crypt import Crypt
+from monstermash.keys import default_config_manager, resolve_decrypt_key, resolve_encrypt_keys
+from monstermash.utils.file import NEW_LINE_EXPR
+
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError as exc:  # pragma: no cover - exercised only when extra is missing
+    raise ImportError(
+        'The Monstermash MCP server requires the optional "mcp" extra. '
+        'Install it with: pip install "monstermash[mcp]"'
+    ) from exc
+
+
+class MCPSettings(BaseSettings):
+    """Settings for the Monstermash MCP server, sourced from the environment.
+
+    Attributes:
+        default_profile (Optional[str]): Profile used by encrypt/decrypt when none is given.
+            Set via ``MONSTERMASH_MCP_DEFAULT_PROFILE``.
+    """
+
+    model_config = SettingsConfigDict(env_prefix='MONSTERMASH_MCP_')
+
+    default_profile: Optional[str] = None
+
+
+mcp = FastMCP('monstermash')
+
+
+def _require_profile(profile: Optional[str]) -> str:
+    """Resolve the profile to use, falling back to the configured default.
+
+    Args:
+        profile (Optional[str]): An explicitly requested profile name.
+
+    Returns:
+        str: The profile name to use.
+
+    Raises:
+        ValueError: If no profile is given and no default is configured.
+    """
+    profile = profile or MCPSettings().default_profile
+    if profile is None:
+        raise ValueError(
+            'no profile specified and no MONSTERMASH_MCP_DEFAULT_PROFILE set; '
+            'create one with the configure tool first'
+        )
+    return profile
+
+
+@mcp.tool()
+def generate_keypair(profile: str) -> dict:
+    """Generate a new Monstermash (NaCl/Curve25519) keypair and store it under a profile.
+
+    The private key is written to the local config file and never returned, so it never enters the
+    model's context. Use the returned public key to receive encrypted messages.
+
+    Args:
+        profile (str): The profile name to create or overwrite with the new keypair.
+
+    Returns:
+        dict: A mapping with the ``profile`` name and the hex-encoded ``public_key``.
+    """
+    keys = Crypt.generate()
+    config_manager = default_config_manager()
+    config = config_manager.read()
+    config[profile] = {
+        'private_key': keys.private_key.get_secret_value(),
+        'public_key': keys.public_key,
+    }
+    config_manager.write(config)
+    return {'profile': profile, 'public_key': keys.public_key}
+
+
+@mcp.tool()
+def encrypt(data: str, public_key: Optional[str] = None, profile: Optional[str] = None) -> str:
+    """Encrypt text using the Monstermash style of encryption.
+
+    The sender's private key is sourced from a stored profile (never passed as an argument). By
+    default the recipient is the profile's own public key; pass ``public_key`` to encrypt to a
+    different recipient.
+
+    Args:
+        data (str): The plaintext to encrypt.
+        public_key (Optional[str]): Hex-encoded recipient public key. Defaults to the profile's.
+        profile (Optional[str]): Profile to source the sender key from. Falls back to the configured
+            default profile.
+
+    Returns:
+        str: The hex-encoded ciphertext.
+    """
+    profile = _require_profile(profile)
+    private_key, public_key = resolve_encrypt_keys(default_config_manager(), profile, None, public_key)
+    crypt = Crypt(private_key.encode())
+    encrypted = crypt.encrypt(data.encode(), public_key.encode())
+    return encrypted.decode()
+
+
+@mcp.tool()
+def decrypt(data: str, profile: Optional[str] = None) -> str:
+    """Decrypt a Monstermash ciphertext.
+
+    The recipient's private key is sourced from a stored profile (never passed as an argument). The
+    sender's public key is read from the ciphertext, so no public key is required.
+
+    Args:
+        data (str): The hex-encoded ciphertext to decrypt.
+        profile (Optional[str]): Profile to source the private key from. Falls back to the configured
+            default profile.
+
+    Returns:
+        str: The decrypted plaintext.
+    """
+    profile = _require_profile(profile)
+    private_key = resolve_decrypt_key(default_config_manager(), profile, None)
+    crypt = Crypt(private_key.encode())
+    decrypted = crypt.decrypt(NEW_LINE_EXPR.sub('', data).encode())
+    return decrypted.decode()
+
+
+@mcp.tool()
+def configure(profile: str, private_key: str, public_key: str) -> str:
+    """Store an existing keypair under a named profile in the Monstermash config file.
+
+    Use this to import keys you already hold. To create fresh keys without ever exposing the private
+    key, use ``generate_keypair`` instead.
+
+    Args:
+        profile (str): The profile name to create or overwrite.
+        private_key (str): Hex-encoded private key to store.
+        public_key (str): Hex-encoded public key to store.
+
+    Returns:
+        str: A confirmation message.
+    """
+    config_manager = default_config_manager()
+    config = config_manager.read()
+    config[profile] = {'private_key': private_key, 'public_key': public_key}
+    config_manager.write(config)
+    return f"Stored profile '{profile}' in the Monstermash config file."
+
+
+@mcp.tool()
+def list_profiles() -> list:
+    """List the names of stored configuration profiles.
+
+    Private keys are never returned; only profile names and their public keys are exposed.
+
+    Returns:
+        list: A list of ``{"profile": name, "public_key": key}`` mappings.
+    """
+    config = default_config_manager().read()
+    return [{'profile': section, 'public_key': config[section].get('public_key')} for section in config.sections()]
+
+
+def main() -> None:
+    """Run the Monstermash MCP server over stdio."""
+    mcp.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/monstermash/parser.py
+++ b/src/monstermash/parser.py
@@ -1,3 +1,4 @@
+import os
 from configparser import ConfigParser
 
 
@@ -25,16 +26,42 @@ class ConfigManager:
 
         Returns:
             ConfigParser: The ConfigParser object with the contents of the configuration file.
+
+        Raises:
+            ValueError: If the file exists but is readable by group or others (POSIX only).
         """
+        self._reject_loose_permissions()
         self.parser.read(self.config_file)
         return self.parser
 
     def write(self, config: ConfigParser):
         """
-        Write a ConfigParser object to the configuration file.
+        Write a ConfigParser object to the configuration file with owner-only (0600) permissions.
+
+        Private keys are stored in plaintext, so the file is created and kept at mode 0600 — the
+        same trust model as an SSH private key.
 
         Args:
             config (ConfigParser): The ConfigParser object to be written to the file.
         """
-        with open(self.config_file, 'w+') as f:
+        fd = os.open(self.config_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, 'w') as f:
             config.write(f)
+        if os.name == 'posix':
+            os.chmod(self.config_file, 0o600)
+
+    def _reject_loose_permissions(self):
+        """Refuse to read a config file that is accessible by group or others.
+
+        Mirrors SSH's refusal to use over-permissive private key files. No-op on non-POSIX
+        platforms and when the file does not yet exist.
+
+        Raises:
+            ValueError: If the file is group- or world-accessible.
+        """
+        if os.name != 'posix' or not os.path.exists(self.config_file):
+            return
+        if os.stat(self.config_file).st_mode & 0o077:
+            raise ValueError(
+                f'config file {self.config_file} is accessible by group/others; ' f'run: chmod 600 {self.config_file}'
+            )

--- a/src/monstermash/utils/file.py
+++ b/src/monstermash/utils/file.py
@@ -26,3 +26,19 @@ def open_file(file) -> Union[Json, str]:
         with open(file, 'r') as f:
             data = f.read()
     return data
+
+
+def read_text(file) -> str:
+    """Read a file's raw contents as text.
+
+    Unlike :func:`open_file`, this never parses JSON — it always returns the file's text verbatim,
+    which is what the encrypt/decrypt commands operate on.
+
+    Args:
+        file (str): The path to the file to read.
+
+    Returns:
+        str: The file contents as text.
+    """
+    with open(file, 'r') as f:
+        return f.read()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,93 @@
+import asyncio
+
+import pytest
+
+from monstermash.crypt import KeyPair
+from monstermash.mcp_server import configure, decrypt, encrypt, generate_keypair, list_profiles, mcp
+
+
+@pytest.fixture
+def temp_config(tmp_path, monkeypatch):
+    """Point the Monstermash config file at a temporary location for the test."""
+    cfg = tmp_path / 'monstermashcfg'
+    monkeypatch.setenv('CONFIG_FILE', str(cfg))
+    return cfg
+
+
+def test_generate_keypair_stores_profile_and_hides_private_key(temp_config):
+    result = generate_keypair('alice')
+    assert set(result) == {'profile', 'public_key'}
+    assert result['profile'] == 'alice'
+    # private key never crosses the boundary
+    assert 'private_key' not in result
+    # but it was persisted server-side
+    profiles = list_profiles()
+    assert profiles == [{'profile': 'alice', 'public_key': result['public_key']}]
+
+
+def test_encrypt_decrypt_roundtrip_via_profiles(temp_config):
+    sender = generate_keypair('sender')
+    recipient = generate_keypair('recipient')
+    ciphertext = encrypt('hello monster', public_key=recipient['public_key'], profile='sender')
+    assert ciphertext != 'hello monster'
+    plaintext = decrypt(ciphertext, profile='recipient')
+    assert plaintext == 'hello monster'
+    # sender's public key is unused for decryption; recipient profile suffices
+    assert sender['public_key'] != recipient['public_key']
+
+
+def test_encrypt_to_own_profile_roundtrip(temp_config):
+    # encrypting with no explicit public_key targets the profile's own key
+    generate_keypair('self')
+    ciphertext = encrypt('note to self', profile='self')
+    assert decrypt(ciphertext, profile='self') == 'note to self'
+
+
+def test_default_profile_from_env(temp_config, monkeypatch):
+    generate_keypair('default')
+    monkeypatch.setenv('MONSTERMASH_MCP_DEFAULT_PROFILE', 'default')
+    ciphertext = encrypt('no profile arg needed')
+    assert decrypt(ciphertext) == 'no profile arg needed'
+
+
+def test_encrypt_requires_a_profile(temp_config):
+    with pytest.raises(ValueError):
+        encrypt('data')
+
+
+def test_decrypt_requires_a_profile(temp_config):
+    with pytest.raises(ValueError):
+        decrypt('deadbeef')
+
+
+def test_unknown_profile_raises_clear_error(temp_config):
+    with pytest.raises(ValueError, match="profile 'ghost' not found"):
+        decrypt('deadbeef', profile='ghost')
+
+
+def test_configure_imports_existing_keys(temp_config, keypair_one: KeyPair, keypair_two: KeyPair):
+    configure('sender', keypair_one.private_key.get_secret_value(), keypair_one.public_key)
+    configure('recipient', keypair_two.private_key.get_secret_value(), keypair_two.public_key)
+    ciphertext = encrypt('via import', profile='sender', public_key=keypair_two.public_key)
+    assert decrypt(ciphertext, profile='recipient') == 'via import'
+
+
+def test_list_profiles_hides_private_keys(temp_config, keypair_one: KeyPair):
+    configure('default', keypair_one.private_key.get_secret_value(), keypair_one.public_key)
+    profiles = list_profiles()
+    assert profiles == [{'profile': 'default', 'public_key': keypair_one.public_key}]
+    assert keypair_one.private_key.get_secret_value() not in str(profiles)
+
+
+def test_tools_registered():
+    tools = asyncio.run(mcp.list_tools())
+    names = {t.name for t in tools}
+    assert names == {'generate_keypair', 'encrypt', 'decrypt', 'configure', 'list_profiles'}
+
+
+def test_mcp_encrypt_decrypt_take_no_private_key_argument():
+    # the security contract: no private_key parameter on the model-facing tools
+    tools = asyncio.run(mcp.list_tools())
+    by_name = {t.name: t for t in tools}
+    assert 'private_key' not in by_name['encrypt'].inputSchema['properties']
+    assert 'private_key' not in by_name['decrypt'].inputSchema['properties']

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,37 @@
+import os
+import stat
+
+import pytest
+
+from monstermash.parser import ConfigManager
+
+
+def _make_config(path):
+    manager = ConfigManager(str(path))
+    config = manager.read()
+    config['default'] = {'private_key': 'abc', 'public_key': 'def'}
+    manager.write(config)
+    return manager
+
+
+@pytest.mark.skipif(os.name != 'posix', reason='POSIX file permissions only')
+def test_write_creates_owner_only_file(tmp_path):
+    cfg = tmp_path / 'cfg'
+    _make_config(cfg)
+    mode = stat.S_IMODE(os.stat(cfg).st_mode)
+    assert mode == 0o600
+
+
+@pytest.mark.skipif(os.name != 'posix', reason='POSIX file permissions only')
+def test_read_rejects_loose_permissions(tmp_path):
+    cfg = tmp_path / 'cfg'
+    manager = _make_config(cfg)
+    os.chmod(cfg, 0o644)
+    with pytest.raises(ValueError, match='accessible by group/others'):
+        manager.read()
+
+
+def test_read_missing_file_is_noop(tmp_path):
+    manager = ConfigManager(str(tmp_path / 'absent'))
+    config = manager.read()
+    assert config.sections() == []

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -105,7 +105,8 @@ def test_encrypt_and_decrypt_priv_pub_file(keypair_one: KeyPair, keypair_two: Ke
     assert replace_new_line(decrypted.output) == replace_new_line(lyrics)
 
 
-def test_configure(keypair_one: KeyPair, lyrics: str):
+def test_configure(keypair_one: KeyPair, lyrics: str, tmp_path, monkeypatch):
+    monkeypatch.setenv('CONFIG_FILE', str(tmp_path / 'monstermashcfg'))
     runner = CliRunner()
     runner.invoke(
         mash,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from monstermash.utils.file import open_file
+from monstermash.utils.file import open_file, read_text
 
 
 def test_txt_file():
@@ -9,3 +9,15 @@ def test_txt_file():
 def test_json_file():
     content = open_file('tests/sample-data.json')
     assert content['artist'] == 'The Crypt-Kicker Five'
+
+
+def test_read_text_returns_string():
+    content = read_text('tests/monstermash-lyrics.txt')
+    assert content.startswith('I was working in the lab, late one night')
+
+
+def test_read_text_does_not_parse_json():
+    # read_text always returns raw text, even for .json — so encrypt --file never gets a dict
+    content = read_text('tests/sample-data.json')
+    assert isinstance(content, str)
+    assert content.strip().startswith('{')

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
 
@@ -14,6 +17,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
 ]
 
 [[package]]
@@ -617,16 +634,62 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "hypothesis"
-version = "6.155.6"
+version = "6.155.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/aa/9a91a4addf285702a98713da44b3581799539426436617bfb8914478c166/hypothesis-6.155.6.tar.gz", hash = "sha256:7569e1897690336c85d49d8391b49ec6ab83d951009515bfc29faebbac286cf5", size = 478038, upload-time = "2026-06-19T13:21:23.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/55/983b6bc1b6b343a5ff6020388f9d0680ab477be59a731517e6c4a0387100/hypothesis-6.155.7.tar.gz", hash = "sha256:d8d6091753d0669db3c90c5e5b346cb37c72f3dd9378c8413acb1fd5da63f7ea", size = 478291, upload-time = "2026-06-21T05:54:31.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a9/4c17e962c2e9cbc314bb579ed2e2b2da45d7b6b942aab6948d14d85abfea/hypothesis-6.155.6-py3-none-any.whl", hash = "sha256:a96d9a29f6bbc8ccac39dd84e140892da76765464929f401a4181b90c20c9ad1", size = 544521, upload-time = "2026-06-19T13:21:20.934Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f8/c151e196d4f397ed9436a071e52666c70a2f021138dea828b0a461e245db/hypothesis-6.155.7-py3-none-any.whl", hash = "sha256:9f634bdb1f9e9b8ab6ba09431cf2deedb750c96978125a6fb3c5a0f6c6db4131", size = 544762, upload-time = "2026-06-21T05:54:29.506Z" },
 ]
 
 [[package]]
@@ -664,7 +727,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.15'" },
+    { name = "zipp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -735,6 +798,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -956,6 +1047,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1161,6 +1277,9 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pymdown-extensions" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 test = [
     { name = "hypothesis" },
     { name = "pytest" },
@@ -1178,7 +1297,8 @@ requires-dist = [
     { name = "dlint", marker = "extra == 'dev'", specifier = ">=0.16.0,<0.17" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=7.3.0,<8" },
     { name = "flake8-bugbear", marker = "extra == 'dev'", specifier = ">=25.11.29,<26.0.0" },
-    { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6.155.3,<7.0.0" },
+    { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6.155.7,<7.0.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.0" },
     { name = "mkautodoc", marker = "extra == 'docs'", specifier = ">=0.2.0,<0.3.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1,<2.0.0" },
     { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = ">=0.4,<0.7" },
@@ -1192,14 +1312,14 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.14.2,<3.0.0" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21.3,<11.0.0" },
     { name = "pynacl", specifier = ">=1.6.2,<2.0.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.1.0,<10.0.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4,<8" },
     { name = "pytest-dotenv", marker = "extra == 'test'", specifier = ">=0.5.2,<0.6.0" },
     { name = "scipy", marker = "extra == 'test'", specifier = ">=1.15.3,<2.0.0" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = ">=67.6,<81.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=6.2.0,<7.0.0" },
 ]
-provides-extras = ["dev", "docs", "test"]
+provides-extras = ["mcp", "dev", "docs", "test"]
 
 [[package]]
 name = "more-itertools"
@@ -1392,7 +1512,10 @@ version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -1747,6 +1870,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pymdown-extensions"
 version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1874,6 +2014,40 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/1b/9cfdeac80ee45bebbbcb31f1b7b99a0d81a1c72de48d837be984e0e88b1d/pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e", size = 6361387, upload-time = "2026-06-04T07:49:14.329Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b1/7afc96d041d982c27bc2df6f853d43f01fd273e3d39d04be3647ddeb533d/pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db", size = 6926780, upload-time = "2026-06-04T07:49:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/4140da9ad54108e517f4a16b2d83da3033e08662144623e1239587cb7db6/pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd", size = 4307203, upload-time = "2026-06-04T07:49:18.993Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1973,6 +2147,21 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2019,6 +2208,275 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/a0/acf8b6fc20bfdcd3a45bd3f57680fb198e157b7e997b9123b10763798bd2/rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036", size = 355609, upload-time = "2026-05-28T11:58:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/95/f8203fd997484b1690a6869cd0e503b6c3c6be55b0ecc36d1a491fe742f0/rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc", size = 348460, upload-time = "2026-05-28T11:58:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8c/b47326ad2f0be545a5e5c1a55937a12afaea7d392ba2837bb9680f57e6c9/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164", size = 381031, upload-time = "2026-05-28T11:58:53.775Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0b/e83bbd97ffac6f6389b605cd4e1c8ac5761dc7e977769c9255d8c5adb7bd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead", size = 387121, upload-time = "2026-05-28T11:58:55.243Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0e/d285d1bc8864245919c61e1ca82263e4a66d337759c3a4cef72766ff9afc/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece", size = 501026, upload-time = "2026-05-28T11:58:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/86/06/ccb2109a1e543437b5e43816f2b43b9554cc6783145528a4e3711e05c011/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb", size = 391865, upload-time = "2026-05-28T11:58:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/237173db1cfef10105b3839a24de00eb8d2a523711add4632447cdf0aedd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda", size = 378012, upload-time = "2026-05-28T11:58:59.589Z" },
+    { url = "https://files.pythonhosted.org/packages/97/64/1eae54e34d5161f9969295e80bd6b62a55f2b6ac5f2a5b60d02c2140e758/rpds_py-2026.5.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a", size = 391111, upload-time = "2026-05-28T11:59:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/34/5bb334a5a0f65d77869217c4654f34c78a7d11b93938a3c076a2edeafc52/rpds_py-2026.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0", size = 409225, upload-time = "2026-05-28T11:59:02.433Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0f/007ec21283b5b040b4ec3bd95e0402591e22bfa7d5c93dfe01c465c2d2d7/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a", size = 556487, upload-time = "2026-05-28T11:59:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/10/5437c94508169b6b22d8418fef7a66e9ffb5f3b9e9c94460f2eedafe06ff/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2", size = 620798, upload-time = "2026-05-28T11:59:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d5/9937dce4d6bda74157b954e7d1460db05a22f5929dccfeeba1ed27a93df0/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2", size = 584053, upload-time = "2026-05-28T11:59:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/31/750617dd0ae1752471bf43f9e41d263398fae7cde7849d23b8574a70e617/rpds_py-2026.5.1-cp311-cp311-win32.whl", hash = "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f", size = 214390, upload-time = "2026-05-28T11:59:08.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bb/3dcab0e1d9516303f2eb672a5d6f62eca5a69e2886301e9c8c54b520c39b/rpds_py-2026.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a", size = 231097, upload-time = "2026-05-28T11:59:09.786Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d6/c6bbf5cb1cf12b9732df8074b57f6ef8341ba884c95d40632ae8bddb44e4/rpds_py-2026.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b", size = 226361, upload-time = "2026-05-28T11:59:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
+    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/bcec1005c4f4a234f92a29078631fee49206c7265ccae966f18fd332e80e/rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6", size = 405009, upload-time = "2026-05-28T11:59:23.845Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/25/2ee807bdb3e1f0b7eddf7782acd5665a8b5205a331a7d7244a52c4812fd9/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24", size = 618838, upload-time = "2026-05-28T11:59:26.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+    { url = "https://files.pythonhosted.org/packages/42/56/3fe0fb34820ff667be791b3a3c22b85e8bcba54e9c832f47438c191fa7be/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea", size = 357151, upload-time = "2026-05-28T12:01:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/3eb9ccdb9f143b8c9b003978898cb497f942a324c077401e6b8834238e63/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb", size = 350195, upload-time = "2026-05-28T12:01:54.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/dbda232bc4f3ed732120692ab0d2c8402cb020516556d8bee622dcef2413/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df", size = 381850, upload-time = "2026-05-28T12:01:56.601Z" },
+    { url = "https://files.pythonhosted.org/packages/40/30/32e769839a358f78810c234f160f2cc21d1e4e47e1c0e0e0d535be5a0219/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7", size = 387899, upload-time = "2026-05-28T12:01:58.212Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/ec84d243aadb3b34b71dd26a010d0930b2d284ff5fc9a69fec53810ee6fd/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc", size = 501618, upload-time = "2026-05-28T12:01:59.888Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/b60e52686bbff777a64f9e4f4d3dd57980dc846913777177a2c92e4937aa/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162", size = 394003, upload-time = "2026-05-28T12:02:01.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c7/b3a6a588cc2219510ef3f42e207483a93950bedd1e3a0fd4015c95cff9e5/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251", size = 379778, upload-time = "2026-05-28T12:02:03.197Z" },
+    { url = "https://files.pythonhosted.org/packages/31/00/c7dba3fc8a3da8cb3f6db1eb3386be4d79c2e97c6890d20eb9ac66ae8c43/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a", size = 392359, upload-time = "2026-05-28T12:02:04.817Z" },
+    { url = "https://files.pythonhosted.org/packages/93/dd/472ba494c70753f93745992c99855bee0636daf74e6984e5e003f150316f/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b", size = 412820, upload-time = "2026-05-28T12:02:06.401Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6f/93831a3bfe789542ed0c1d0d74b78b440f055d6dc3ea4640eba2d95e6e23/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34", size = 557243, upload-time = "2026-05-28T12:02:08.013Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ff/0b3d604614ffc77522c6b288fdbce68957eb583da1002aa65ba38ac0ee40/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c", size = 623541, upload-time = "2026-05-28T12:02:09.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ea/e7b0251441da9adfeaebcf29601d10f2a1455fcf0772fae9e7e19032bd96/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049", size = 586326, upload-time = "2026-05-28T12:02:11.47Z" },
 ]
 
 [[package]]
@@ -2086,7 +2544,10 @@ version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -2160,8 +2621,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version < '3.11' or python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version < '3.11' or python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -2193,6 +2654,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -2297,6 +2784,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Extends Monstermash with an **optional MCP server** so an LLM can use Monstermash-style (NaCl/Curve25519) encryption natively, adds four agent **skills**, a **cryptography domain doc**, and the **security hardening** surfaced by a conduit review of the new code.

## MCP server (`pip install "monstermash[mcp]"`)
- `monstermash-mcp` stdio server with tools: `generate_keypair`, `encrypt`, `decrypt`, `configure`, `list_profiles`.
- **Private keys never cross the model boundary**: `encrypt`/`decrypt` take a `profile` name only (ssh-agent model); the server reads the key from disk locally. `MONSTERMASH_MCP_DEFAULT_PROFILE` sets a default. `generate_keypair` writes straight to a profile and returns only the public key.
- Shared `keys.py` key-resolution module used by both the CLI and the MCP server (single source of truth).

## Security hardening (conduit review findings)
- **H2**: `ConfigManager` writes `~/.monstermashcfg` at `0600` and refuses to read group/world-accessible files (SSH-style). Private keys are plaintext at rest by design.
- **M1**: `ProfileConfig` pydantic model validates the config boundary, raising loud, clear errors instead of bare `KeyError`.
- **M2**: `read_text` for encrypt/decrypt file input — `open_file`'s JSON branch could return a `dict` and crash on `.encode()`.
- **L1**: `Crypt.public_key` uses the public NaCl API (`RawEncoder`) instead of a private attribute.

## Docs & skills
- `docs/domain/cryptography.md` — domain documentation (ubiquitous language incl. *Mashed Envelope*, bounded contexts, events, decisions, open questions).
- `.claude/skills/`: `domain-doc`, `conduit-core`, `conduit-py`, `ship-and-watch`.

## Tests
- New `test_mcp_server.py` (profile-only API, no `private_key` argument on the model-facing tools, env-default profile, clear errors) and `test_parser.py` (0600 enforcement, loose-perm rejection). `test_configure` isolated to a tmp config file.
- Full suite: **28 passed**, coverage 91%. Pre-commit (ruff, black, mypy, isort) green.