### PR TITLE
Refresh README and bump to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,65 @@
-##  🧟 Monstermash
+## 🧟 Monstermash
 
-> 1️⃣ version: 2.0.0
+> _"He did the mash. He did the monster mash."_
 
-> ✍️ author: Mitchell Lisle
+**Encryption that doesn't bite.** Monstermash wraps the battle-tested [NaCl](https://nacl.cr.yp.to/)
+(libsodium) cryptography in a friendly CLI, a clean Python API, and an MCP server — so developers,
+engineers, and now AI agents can encrypt things correctly without touching a single cryptographic
+knob.
+
+> 1️⃣ version: 2.0.0 &nbsp;·&nbsp; ✍️ author: Mitchell Lisle
+
+![PyPI](https://img.shields.io/pypi/v/monstermash)
+![Python](https://img.shields.io/pypi/pyversions/monstermash)
+
+---
+
+## Why Monstermash?
+
+- 🔒 **Safe by default** — built on NaCl's `Box` (Curve25519 + XSalsa20-Poly1305). No hand-rolled
+  crypto, no caller-managed nonces, no footguns.
+- 🪄 **Decrypt with just your private key** — the sender's public key rides *inside* the ciphertext
+  (the "Mashed Envelope"), so the recipient needs nothing extra.
+- 🧰 **One tool, three surfaces** — the same guarantees from the CLI, the Python library, and an
+  optional MCP server for LLMs.
+- 🗝️ **Profiles, not key-juggling** — store keypairs once (mode `0600`, just like your SSH keys) and
+  reference them by name.
+- 🚨 **Tamper-evident** — authenticated encryption fails *loudly*; a corrupted or wrong-key
+  ciphertext raises, it never returns garbage.
 
 ## Install
-Install from PyPi
 
 ```shell
 pip install monstermash
 ```
 
-## Usage
-Monstermash can generate keys, encrypt files or text with keys, and decrypt a file or text
+Want the MCP server for AI agents? Grab the optional extra:
 
-### Generate Keys
+```shell
+pip install "monstermash[mcp]"
+```
+
+## Quickstart
+
+### 1. Generate a keypair
+
 ```shell
 monstermash generate
 ```
 
 ```text
 -----------------
-Private Key (keep is secret, keep it safe)
+Private Key (keep it secret, keep it safe)
 a715a3d11d0f9c13de3bd6d390e36ba4e3322f4f2e4f1a13a54ba85be606de87
 Public Key (you can share this one)
 01765c67f451f3175f53bbe11d69d73a36d45074da935271473b4a1c460e3d79
 -----------------
 ```
 
-### Store configuration
-```text
-Usage: monstermash configure [OPTIONS]
+### 2. Save it as a profile (optional, but nice)
 
-Options:
-  --profile TEXT      The name of the profile you want to create.
-  --private-key TEXT  Your private key.
-  --public-key TEXT   Your public key.
-  --help              Show this message and exit.
+Profiles live in `~/.monstermashcfg` and are written with owner-only (`0600`) permissions.
 
-```
 ```shell
 monstermash configure \
   --profile default \
@@ -46,61 +67,61 @@ monstermash configure \
   --public-key 01765c67f451f3175f53bbe11d69d73a36d45074da935271473b4a1c460e3d79
 ```
 
-### Encrypt text or file
-```text
-Usage: monstermash encrypt [OPTIONS]
+### 3. Encrypt
 
-Options:
-  --profile TEXT
-  --private-key TEXT  Your private key.
-  --public-key TEXT   Your public key.
-  --file TEXT         The path to the file you want to encrypt
-  --data TEXT         Input data you want to encrypt
-  --help              Show this message and exit.
+```shell
+monstermash encrypt --profile default --data "hello world"
 ```
+
+Or pass keys explicitly, or encrypt a whole file:
 
 ```shell
 monstermash encrypt \
-  --profile default \
+  --private-key a715a3d11d0f9c13de3bd6d390e36ba4e3322f4f2e4f1a13a54ba85be606de87 \
   --public-key 03ab4b8a77456729678a8022c2bfe22f64ed2db72692903e5f69e4a92649e646 \
-  --data "hello world"
+  --file ./secret-plans.txt
 ```
 
-### Decryption text
-```text
-Usage: monstermash decrypt [OPTIONS]
-
-Options:
-  --profile TEXT
-  --private-key TEXT  Your private key.
-  --file TEXT         The path to the file you want to encrypt
-  --data TEXT         Input data you want to encrypt
-  --help              Show this message and exit.
-```
+### 4. Decrypt
 
 ```shell
 monstermash decrypt \
-  --private-key 91c7b2534454587a3330537bce60056e9da9a9bf75d32507152f49e85514970d
+  --private-key 91c7b2534454587a3330537bce60056e9da9a9bf75d32507152f49e85514970d \
   --data 01765c67f451f3175f53bbe11d69d73a36d45074da935271473b4a1c460e3d797bee92fa7ff1216eb5324b247fd41cce283adbcc4df92baacfea27765360a7c0feb226cccc1538c0397783003d0283d2841d2a
 ```
 
-## MCP Server
-Monstermash ships an optional [Model Context Protocol](https://modelcontextprotocol.io) server
-so an LLM can generate keys, encrypt, and decrypt data natively using Monstermash encryption.
+The `--profile` flag works here too — no public key needed, it's baked into the ciphertext.
 
-Install with the `mcp` extra:
+## How it works
 
-```shell
-pip install "monstermash[mcp]"
+Monstermash owns **no cryptographic primitives** — it leans entirely on NaCl. What it adds is
+ergonomics:
+
+```text
+plaintext ──▶ NaCl Box (Curve25519 + XSalsa20-Poly1305) ──▶ [ sender public key │ nonce │ MAC │ ciphertext ] ──▶ hex
+                                                                └──────────── the "Mashed Envelope" ────────────┘
 ```
 
-Run the server over stdio:
+Because the sender's public key travels inside the envelope, the recipient decrypts with only their
+private key. See [`docs/domain/cryptography.md`](docs/domain/cryptography.md) for the full domain
+model and design decisions.
+
+## MCP Server
+
+Monstermash ships an optional [Model Context Protocol](https://modelcontextprotocol.io) server so an
+LLM can do real encryption natively — without ever handling raw private keys.
+
+**Security model:** tool arguments flow into the model's context, so private keys **never cross the
+boundary**. The model works by *profile name* (à la `ssh-agent`); the server reads the key from disk
+locally. Set a default with `MONSTERMASH_MCP_DEFAULT_PROFILE`.
+
+Run it over stdio:
 
 ```shell
 monstermash-mcp
 ```
 
-Register it with an MCP client (e.g. Claude Desktop) by pointing the client at the command:
+Register it with an MCP client (e.g. Claude Desktop):
 
 ```json
 {
@@ -112,12 +133,16 @@ Register it with an MCP client (e.g. Claude Desktop) by pointing the client at t
 }
 ```
 
-The server exposes these tools:
+### Tools
 
 | Tool | Description |
 | --- | --- |
-| `generate_keypair` | Generate a new private/public keypair. |
-| `encrypt` | Encrypt text with explicit keys or a stored profile. |
-| `decrypt` | Decrypt a ciphertext with a private key or stored profile. |
-| `configure` | Store a keypair under a named profile. |
-| `list_profiles` | List stored profile names and public keys (private keys are never returned). |
+| `generate_keypair` | Generate a keypair, store it under a profile, and return only the public key. |
+| `encrypt` | Encrypt text using a profile's keys (recipient defaults to the profile; override with `public_key`). |
+| `decrypt` | Decrypt a ciphertext using a profile's private key. |
+| `configure` | Import an existing keypair under a named profile. |
+| `list_profiles` | List profile names and public keys — **private keys are never returned**. |
+
+## License
+
+See the repository for license details.

--- a/uv.lock
+++ b/uv.lock
@@ -1310,7 +1310,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0,<5.0.0" },
     { name = "pydantic", specifier = ">=2.13.4,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2,<3.0.0" },
-    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21.3,<11.0.0" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0,<12.0.0" },
     { name = "pynacl", specifier = ">=1.6.2,<2.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4,<8" },
@@ -1888,15 +1888,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Polishes the README for the 2.0.0 release and bumps the version.

- **README refresh** — tagline, "Why Monstermash?" feature highlights, a Mashed-Envelope diagram, a step-by-step quickstart, and PyPI/Python badges. Links the cryptography domain doc.
- **Accuracy fix** — the MCP tools table previously described `encrypt`/`decrypt` as taking explicit/private keys. Updated to reflect the **profile-only** key handling shipped in #707 (private keys never cross the model boundary).
- **Version bump** — `1.13.1 -> 2.0.0` across `pyproject.toml`, `src/monstermash/__init__.py`, `Makefile`, `setup.cfg`, and `uv.lock`. Major bump is warranted: new MCP surface + the breaking MCP API change (profile-only).

## Verification
- Full suite: **28 passed**. Pre-commit (ruff, black, mypy, isort) green.